### PR TITLE
flexibelere createConnection & getHeaders

### DIFF
--- a/lib/connection_data.php
+++ b/lib/connection_data.php
@@ -1,5 +1,0 @@
-<?php
-$servername = "localhost";
-$username = "root";
-$password = "";
-$dbname = "steden";

--- a/lib/pdo.php
+++ b/lib/pdo.php
@@ -1,54 +1,86 @@
 <?php
 require_once "autoload.php";
 
-function CreateConnection()
-{
-    global $conn;
-    global $servername, $dbname, $username, $password;
+function CreateConnection($db){
+    // json file inlezen en omzetten naar associatieve array
+    $file = file_get_contents("../config.json");
+    $config = json_decode($file, true)["DATABASE"][$db];
+
+
+    $servername = $config["host"];
+    $dbname = $config["dbname"];
+    $username = $config["username"];
+    $password = $config["password"];
 
     // Create and check connection
     try {
         $conn = new PDO("mysql:host=$servername;dbname=$dbname", $username, $password);
         $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        return $conn;
     }
     catch(PDOException $e) {
         echo "Connection failed: " . $e->getMessage();
     }
 }
 
-function GetData( $sql )
-{
-    global $conn;
-
-    CreateConnection();
+function GetData( $sql, $db="LIVE"){
+    // create connection
+    $conn = CreateConnection($db);
 
     //define and execute query
     $result = $conn->query( $sql );
 
-    //show result (if there is any)
-    if ( $result->rowCount() > 0 )
-    {
-        //$rows = $result->fetchAll(PDO::FETCH_ASSOC); //geeft array zoals ['lan_id'] => 1, ...
-        //$rows = $result->fetchAll(PDO::FETCH_NUM); //geeft array zoals [0] => 1, ...
-        $rows = $result->fetchAll(PDO::FETCH_BOTH); //geeft array zoals [0] => 1, ['lan_id'] => 1, ...
-        //var_dump($rows);
-        return $rows;
-    }
-    else
-    {
-        return [];
-    }
+    // return all rows if data found else return an empty array
+    return $result->rowCount() > 0 ? $result->fetchALL(PDO::FETCH_ASSOC) : [];
 
 }
 
-function ExecuteSQL( $sql )
-{
-    global $conn;
-
-    CreateConnection();
+function ExecuteSQL( $sql, $db="LIVE" ){
+    // create connection
+    $conn = CreateConnection( $db );
 
     //define and execute query
     $result = $conn->query( $sql );
 
     return $result;
 }
+
+
+/**
+* functie die de tabelhoofdingen van de tabel opvraagt en teruggeeft.
+* @param $table: tabel waarvoor de hoofdingen gevraagd wordt.
+* @type $table: string
+*
+* @return: array(string => array(string => string|int))
+*/
+function getHeaders($table, $db="LIVE"): array{
+        $headers = [];
+        // aanmaken connectie & query
+        $conn = CreateConnection($db);
+        $db = getData("select database()")[0]["database()"];
+        $query = "select * from information_schema.columns where table_name = '$table' and table_schema = '$db'";
+
+        // opvragen data ahv bovenstaande query
+        $data = GetData($query);
+
+        // voor iedere rij (gevevens van 1 kolom) nagaan en uithalen wat van belang is.
+        foreach($data as $row){
+            // belangrijke eigenschappen van de rij (gegevens van 1 kolom) zijn:
+            // COLUMN_NAME - DATA_TYPE - COLUMN_KEY - CHARACTER_MAXIMUM_LENGTH - IS_NULLABLE
+            $column = $row["COLUMN_NAME"];
+            $column_datatype = $row["DATA_TYPE"];
+            $column_key = $row["COLUMN_KEY"];
+            $column_max_length = $row["CHARACTER_MAXIMUM_LENGTH"];
+            $is_null = $row["IS_NULLABLE"];
+
+            // nieuwe associatieve array aanmaken met nodige data. en toevoegen aan de $headers array
+            $headers[$column] = [];
+            $headers[$column]["datatype"] = $column_datatype;
+            $headers[$column]["key"] = $column_key;
+            $headers[$column]["max_size"] = $column_max_length;
+            $headers[$column]["can_be_null"] = $is_null;
+
+        }
+        $_POST["DB_HEADERS"] = $headers;
+        return $headers;
+    }


### PR DESCRIPTION
CreateConnection kan makkelijker connectie leggen naar verschillende databanken (bv live, test, local,...).
getHeaders is ter vervanging van de query "SHOW FULL COLUMNS FROM $table".
    - niet meer nodig om op zoek te gaan naar de maximum aantal characters van een varchar, etc